### PR TITLE
Fix containerd issue 12247

### DIFF
--- a/client/snapshotter_opts_unix.go
+++ b/client/snapshotter_opts_unix.go
@@ -33,6 +33,7 @@ import (
 const (
 	capaRemapIDs     = "remap-ids"
 	capaOnlyRemapIDs = "only-remap-ids"
+	capaSlowChown    = "slow-chown"
 )
 
 // WithRemapperLabels creates the labels used by any supporting snapshotter
@@ -100,7 +101,16 @@ func resolveSnapshotOptions(ctx context.Context, client *Client, snapshotterName
 		}
 	}
 
-	if capaOnlyRemap {
+	// Check if the snapshotter supports slow_chown fallback
+	hasSlowChown := false
+	for _, capa := range capabs {
+		if capa == capaSlowChown {
+			hasSlowChown = true
+			break
+		}
+	}
+
+	if capaOnlyRemap && !hasSlowChown {
 		return "", fmt.Errorf("snapshotter %q doesn't support idmap mounts on this host, configure `slow_chown` to allow a slower and expensive fallback", snapshotterName)
 	}
 

--- a/plugins/snapshots/overlay/overlay.go
+++ b/plugins/snapshots/overlay/overlay.go
@@ -263,7 +263,117 @@ func (o *snapshotter) Usage(ctx context.Context, key string) (_ snapshots.Usage,
 }
 
 func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
-	return o.createSnapshot(ctx, snapshots.KindActive, key, parent, opts)
+	var (
+		s        storage.Snapshot
+		td, path string
+		info     snapshots.Info
+		err      error
+	)
+
+	defer func() {
+		if err != nil {
+			if td != "" {
+				if err1 := os.RemoveAll(td); err1 != nil {
+					log.G(ctx).WithError(err1).Warn("failed to cleanup temp snapshot directory")
+				}
+			}
+			if path != "" {
+				if err1 := os.RemoveAll(path); err1 != nil {
+					log.G(ctx).WithError(err1).WithField("path", path).Error("failed to reclaim snapshot directory, directory may need removal")
+					err = fmt.Errorf("failed to remove path: %v: %w", err1, err)
+				}
+			}
+		}
+	}()
+
+	if err := o.ms.WithTransaction(ctx, true, func(ctx context.Context) (err error) {
+		snapshotDir := filepath.Join(o.root, "snapshots")
+		td, err = o.prepareDirectory(ctx, snapshotDir, snapshots.KindActive)
+		if err != nil {
+			return fmt.Errorf("failed to create prepare snapshot dir: %w", err)
+		}
+
+		s, err = storage.CreateSnapshot(ctx, snapshots.KindActive, key, parent, opts...)
+		if err != nil {
+			return fmt.Errorf("failed to create snapshot: %w", err)
+		}
+
+		_, info, _, err = storage.GetInfo(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to get snapshot info: %w", err)
+		}
+
+		var (
+			mappedUID, mappedGID     = -1, -1
+			uidmapLabel, gidmapLabel string
+			needsRemap               = false
+		)
+		// NOTE: if idmapped mounts' supported by hosted kernel there may be
+		// no parents at all, so overlayfs will not work and snapshotter
+		// will use bind mount. To be able to create file objects inside the
+		// rootfs -- just chown this only bound directory according to provided
+		// {uid,gid}map. In case of one/multiple parents -- chown upperdir.
+		if v, ok := info.Labels[snapshots.LabelSnapshotUIDMapping]; ok {
+			uidmapLabel = v
+			needsRemap = true
+		}
+		if v, ok := info.Labels[snapshots.LabelSnapshotGIDMapping]; ok {
+			gidmapLabel = v
+			needsRemap = true
+		}
+
+		if needsRemap {
+			var idMap userns.IDMap
+			if err = idMap.Unmarshal(uidmapLabel, gidmapLabel); err != nil {
+				return fmt.Errorf("failed to unmarshal snapshot ID mapped labels: %w", err)
+			}
+			root, err := idMap.RootPair()
+			if err != nil {
+				return fmt.Errorf("failed to find root pair: %w", err)
+			}
+			mappedUID, mappedGID = int(root.Uid), int(root.Gid)
+		}
+
+		if mappedUID == -1 || mappedGID == -1 {
+			if len(s.ParentIDs) > 0 {
+				st, err := os.Stat(o.upperPath(s.ParentIDs[0]))
+				if err != nil {
+					return fmt.Errorf("failed to stat parent: %w", err)
+				}
+				stat, ok := st.Sys().(*syscall.Stat_t)
+				if !ok {
+					return fmt.Errorf("incompatible types after stat call: *syscall.Stat_t expected")
+				}
+				mappedUID = int(stat.Uid)
+				mappedGID = int(stat.Gid)
+			}
+		}
+
+		if mappedUID != -1 && mappedGID != -1 {
+			if o.slowChown {
+				// Use recursive chown for slow_chown fallback
+				if err := o.RecursiveChown(filepath.Join(td, "fs"), mappedUID, mappedGID); err != nil {
+					return fmt.Errorf("failed to recursive chown: %w", err)
+				}
+			} else {
+				// Use simple chown for idmap mounts
+				if err := os.Lchown(filepath.Join(td, "fs"), mappedUID, mappedGID); err != nil {
+					return fmt.Errorf("failed to chown: %w", err)
+				}
+			}
+		}
+
+		path = filepath.Join(snapshotDir, s.ID)
+		if err = os.Rename(td, path); err != nil {
+			return fmt.Errorf("failed to rename: %w", err)
+		}
+		td = ""
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return o.mounts(s, info), nil
 }
 
 func (o *snapshotter) View(ctx context.Context, key, parent string, opts ...snapshots.Opt) ([]mount.Mount, error) {
@@ -512,8 +622,16 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		}
 
 		if mappedUID != -1 && mappedGID != -1 {
-			if err := os.Lchown(filepath.Join(td, "fs"), mappedUID, mappedGID); err != nil {
-				return fmt.Errorf("failed to chown: %w", err)
+			if o.slowChown {
+				// Use recursive chown for slow_chown fallback
+				if err := o.RecursiveChown(filepath.Join(td, "fs"), mappedUID, mappedGID); err != nil {
+					return fmt.Errorf("failed to recursive chown: %w", err)
+				}
+			} else {
+				// Use simple chown for idmap mounts
+				if err := os.Lchown(filepath.Join(td, "fs"), mappedUID, mappedGID); err != nil {
+					return fmt.Errorf("failed to chown: %w", err)
+				}
 			}
 		}
 
@@ -633,4 +751,19 @@ func supportsIndex() bool {
 		return true
 	}
 	return false
+}
+
+// RecursiveChown recursively changes ownership of all files and directories
+// starting from the given path. This is used as a fallback when idmap mounts
+// are not available and slow_chown is enabled.
+func (o *snapshotter) RecursiveChown(path string, uid, gid int) error {
+	return filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := os.Lchown(path, uid, gid); err != nil {
+			return fmt.Errorf("failed to chown %s: %w", path, err)
+		}
+		return nil
+	})
 }

--- a/plugins/snapshots/overlay/overlay_slow_chown_test.go
+++ b/plugins/snapshots/overlay/overlay_slow_chown_test.go
@@ -1,0 +1,112 @@
+//go:build linux
+
+package overlay
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/internal/userns"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestSnapshotterWithSlowChown(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+	
+	// Create a snapshotter with slow_chown enabled
+	s, err := NewSnapshotter(tmpDir, WithSlowChown)
+	if err != nil {
+		t.Fatalf("Failed to create snapshotter: %v", err)
+	}
+	defer s.Close()
+
+	// Create a snapshot with user namespace mapping
+	ctx := context.Background()
+	key := "test-snapshot"
+	parent := ""
+
+	// Create ID mappings for user namespace
+	uidMaps := []specs.LinuxIDMapping{{ContainerID: 0, HostID: 1000, Size: 65536}}
+	gidMaps := []specs.LinuxIDMapping{{ContainerID: 0, HostID: 1000, Size: 65536}}
+	
+	idMap := userns.IDMap{
+		UidMap: uidMaps,
+		GidMap: gidMaps,
+	}
+	uidmapLabel, gidmapLabel := idMap.Marshal()
+
+	opts := []snapshots.Opt{
+		snapshots.WithLabels(map[string]string{
+			snapshots.LabelSnapshotUIDMapping: uidmapLabel,
+			snapshots.LabelSnapshotGIDMapping: gidmapLabel,
+		}),
+	}
+
+	// Prepare the snapshot
+	mounts, err := s.Prepare(ctx, key, parent, opts...)
+	if err != nil {
+		t.Fatalf("Failed to prepare snapshot: %v", err)
+	}
+
+	// Verify that mounts were created
+	if len(mounts) == 0 {
+		t.Fatal("No mounts returned from Prepare")
+	}
+
+	// Clean up
+	if err := s.Remove(ctx, key); err != nil {
+		t.Fatalf("Failed to remove snapshot: %v", err)
+	}
+}
+
+func TestSnapshotterWithoutSlowChown(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+	
+	// Create a snapshotter without slow_chown enabled
+	s, err := NewSnapshotter(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create snapshotter: %v", err)
+	}
+	defer s.Close()
+
+	// Create a snapshot with user namespace mapping
+	ctx := context.Background()
+	key := "test-snapshot"
+	parent := ""
+
+	// Create ID mappings for user namespace
+	uidMaps := []specs.LinuxIDMapping{{ContainerID: 0, HostID: 1000, Size: 65536}}
+	gidMaps := []specs.LinuxIDMapping{{ContainerID: 0, HostID: 1000, Size: 65536}}
+	
+	idMap := userns.IDMap{
+		UidMap: uidMaps,
+		GidMap: gidMaps,
+	}
+	uidmapLabel, gidmapLabel := idMap.Marshal()
+
+	opts := []snapshots.Opt{
+		snapshots.WithLabels(map[string]string{
+			snapshots.LabelSnapshotUIDMapping: uidmapLabel,
+			snapshots.LabelSnapshotGIDMapping: gidmapLabel,
+		}),
+	}
+
+	// Prepare the snapshot
+	mounts, err := s.Prepare(ctx, key, parent, opts...)
+	if err != nil {
+		t.Fatalf("Failed to prepare snapshot: %v", err)
+	}
+
+	// Verify that mounts were created
+	if len(mounts) == 0 {
+		t.Fatal("No mounts returned from Prepare")
+	}
+
+	// Clean up
+	if err := s.Remove(ctx, key); err != nil {
+		t.Fatalf("Failed to remove snapshot: %v", err)
+	}
+}

--- a/plugins/snapshots/overlay/plugin/plugin.go
+++ b/plugins/snapshots/overlay/plugin/plugin.go
@@ -32,6 +32,7 @@ import (
 const (
 	capaRemapIDs     = "remap-ids"
 	capaOnlyRemapIDs = "only-remap-ids"
+	capaSlowChown    = "slow-chown"
 )
 
 // Config represents configuration for the overlay plugin.
@@ -86,6 +87,8 @@ func init() {
 
 			if config.SlowChown {
 				oOpts = append(oOpts, overlay.WithSlowChown)
+				// Add slow-chown capability to signal that slow chown fallback is available
+				ic.Meta.Capabilities = append(ic.Meta.Capabilities, capaSlowChown)
 			} else {
 				// If slowChown is false, we use capaOnlyRemapIDs to signal we only
 				// allow idmap mounts.


### PR DESCRIPTION
Implement `slow_chown` fallback for the overlay snapshotter to support idmapped mounts on older kernels.

Previously, the overlay snapshotter would error out when idmapped mounts were requested on kernels older than 5.19 (which lack native idmapped mount support), even though a `slowChown` option existed but was not fully implemented. This PR enables a recursive chown fallback when `slow_chown = true` is configured, allowing these operations to succeed without requiring kernel 5.19+.

---
<a href="https://cursor.com/background-agent?bcId=bc-28517ba3-ccd0-4fe8-a695-d56460c96e83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28517ba3-ccd0-4fe8-a695-d56460c96e83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

